### PR TITLE
Voice UI/UX v1: fixed mic zone, stateful icons, natural copy

### DIFF
--- a/app/core/state.py
+++ b/app/core/state.py
@@ -121,9 +121,9 @@ class UiState:
     pending_reorder: bool = False
     reorder_due_at: float = 0.0
 
-    # Voice overlay stub (TSX: long press/Space enters listening overlay on the clock panel).
+    # Voice UI zone state (used by simulator + board render paths).
     voice_active: bool = False
-    voice_phase: str = "idle"  # "idle" | "recording" | "processing" | "done" | "error"
+    voice_phase: str = "idle"  # "idle" | "recording" | "processing" | "confirm" | "done" | "error"
     voice_message: str = ""
     voice_due_at: float = 0.0
     voice_confirm_tool: str = ""

--- a/app/ui/app.py
+++ b/app/ui/app.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from PIL import ImageDraw
+import time
+
+from PIL import Image, ImageDraw
 
 from app.core.state import AppState, Screen, MenuItemId, WidgetMode
 from app.ui.home import render_home
@@ -12,19 +14,22 @@ from app.ui.placeholder import render_placeholder
 from app.ui.layout import compute_layout
 
 
-def _voice_overlay_title(phase: str) -> str:
+def _voice_zone_status_label(phase: str, msg: str = "") -> str:
     p = (phase or "idle").strip().lower()
     if p == "recording":
-        return "RECORDING"
+        return "LISTENING"
     if p == "processing":
         return "PROCESSING"
     if p == "confirm":
         return "CONFIRM"
     if p == "done":
+        txt = str(msg or "").strip().lower()
+        if txt.startswith("skipped:") or "\nresult: skipped:" in txt:
+            return "SKIPPED"
         return "DONE"
     if p == "error":
         return "ERROR"
-    return "VOICE"
+    return "READY"
 
 
 def _voice_wrap_message(msg: str, max_chars: int = 44, max_lines: int = 3) -> list[str]:
@@ -65,58 +70,504 @@ def _voice_wrap_message(msg: str, max_chars: int = 44, max_lines: int = 3) -> li
     return lines
 
 
+def _parse_voice_message_fields(msg: str) -> dict[str, str | list[str]]:
+    text = str(msg or "").strip()
+    out: dict[str, str | list[str]] = {"heard": "", "action": "", "result": "", "other": []}
+    if not text:
+        return out
+
+    other: list[str] = []
+    for raw in text.splitlines():
+        line = " ".join(str(raw or "").strip().split())
+        if not line:
+            continue
+        head, sep, tail = line.partition(":")
+        key = head.strip().lower()
+        value = tail.strip()
+        if sep and key in ("heard", "action", "result"):
+            out[key] = value
+            continue
+        other.append(line)
+    out["other"] = other
+    return out
+
+
+def _voice_zone_lines(phase_label: str, msg: str, *, max_chars: int = 36) -> list[str]:
+    fields = _parse_voice_message_fields(msg)
+    heard = str(fields.get("heard") or "").strip()
+    result = str(fields.get("result") or "").strip()
+    other = [str(x).strip() for x in (fields.get("other") or []) if str(x).strip()]
+
+    lines: list[str] = []
+    max_lines = 3
+
+    def _append(text: str) -> None:
+        if not text or len(lines) >= max_lines:
+            return
+        remain = max_lines - len(lines)
+        for wrapped in _voice_wrap_message(text, max_chars=max_chars, max_lines=remain):
+            if len(lines) >= max_lines:
+                break
+            lines.append(wrapped)
+
+    if phase_label == "LISTENING":
+        _append(other[0] if other else (result or "Listening for command"))
+        return lines or ["Listening for command"]
+
+    if phase_label == "PROCESSING":
+        _append(other[0] if other else (result or "Interpreting command"))
+        return lines or ["Interpreting command"]
+
+    if phase_label == "CONFIRM":
+        if heard:
+            _append(f"Heard: {heard}")
+        # Keep confirm body compact; the explicit device action/countdown lives in the hint row.
+        if result:
+            result_l = result.lower()
+            if "confirm" in result_l or "press click" in result_l or "press" in result_l:
+                _append("Result: Awaiting physical confirm")
+            else:
+                _append(f"Result: {result}")
+        elif other:
+            _append(other[0])
+        if not lines:
+            return ["Confirm action on device"]
+        return lines
+
+    if heard:
+        _append(f"Heard: {heard}")
+
+    if result:
+        _append(f"Result: {result}")
+    elif other:
+        _append(other[0])
+        if len(other) > 1:
+            _append(other[1])
+    elif msg:
+        _append(msg)
+
+    if not lines:
+        if phase_label == "CONFIRM":
+            return ["Confirm action on device"]
+        if phase_label == "ERROR":
+            return ["Voice command failed"]
+        return ["Voice update"]
+    return lines
+
+
+def _voice_zone_hint(state: AppState, phase_label: str, *, active: bool) -> str:
+    return ""
+
+
+_MIC_STYLE_ALIASES: dict[str, str] = {
+    "hero_solid": "heroicons_solid",
+    "hero_outline": "heroicons_outline",
+    "capsule_solid": "bootstrap_fill",
+    "block_solid": "tabler_filled",
+    "outline": "heroicons_outline",
+    "lucide_outline": "heroicons_outline",
+    "retro": "tabler_outline",
+}
+
+_MIC_ICON_MASKS_16: dict[str, tuple[str, ...]] = {
+    # Heroicons solid (source: assets/icons/heroicons/16-solid-microphone.svg)
+    # Mask extracted from vector render and tuned for 1-bit readability.
+    "heroicons_solid": (
+        "................",
+        "......####......",
+        "......####......",
+        "......####......",
+        "......####......",
+        "......####......",
+        "...#..####..#...",
+        "...##.####.##...",
+        "...##.####.##...",
+        "...###....###...",
+        "....########....",
+        ".....######.....",
+        ".......##.......",
+        ".....######.....",
+        ".....######.....",
+        "................",
+    ),
+    # Heroicons outline (derived from heroicons solid contour for e-paper).
+    "heroicons_outline": (
+        "................",
+        "......####......",
+        "......#..#......",
+        "......#..#......",
+        "......#..#......",
+        "......#..#......",
+        "...#..#..#..#...",
+        "...##.#..#.##...",
+        "...##.####.##...",
+        "...###....###...",
+        "....########....",
+        ".....######.....",
+        ".......##.......",
+        ".....######.....",
+        ".....######.....",
+        "................",
+    ),
+    # Tabler outline (source: assets/icons/tabler/microphone-outline.svg)
+    "tabler_outline": (
+        "................",
+        "......####......",
+        "......####......",
+        ".....##..##.....",
+        ".....##..##.....",
+        ".....##..##.....",
+        "...#.##..##.#...",
+        "...#.##..##.#...",
+        "...##.####.##...",
+        "...##..##..##...",
+        "....###..###....",
+        ".....######.....",
+        ".......##.......",
+        ".....######.....",
+        ".....######.....",
+        "................",
+    ),
+    # Tabler filled (source: assets/icons/tabler/microphone-filled.svg)
+    "tabler_filled": (
+        "................",
+        "......####......",
+        "......####......",
+        ".....######.....",
+        ".....######.....",
+        ".....######.....",
+        "...#.######.#...",
+        "...#.######.#...",
+        "...##.####.##...",
+        "...##..##..##...",
+        "....###..###....",
+        ".....######.....",
+        ".......##.......",
+        ".....######.....",
+        ".....######.....",
+        "................",
+    ),
+    # Tabler half-fill (mid-state between outline and filled for processing/confirm).
+    "tabler_half": (
+        "................",
+        "......####......",
+        "......####......",
+        ".....##..##.....",
+        ".....######.....",
+        ".....######.....",
+        "...#.######.#...",
+        "...#.##..##.#...",
+        "...##.####.##...",
+        "...##..##..##...",
+        "....###..###....",
+        ".....######.....",
+        ".......##.......",
+        ".....######.....",
+        ".....######.....",
+        "................",
+    ),
+    # Bootstrap outline (source: assets/icons/bootstrap/mic.svg)
+    "bootstrap_outline": (
+        "................",
+        "......####......",
+        "......#..#......",
+        ".....##..##.....",
+        ".....##..##.....",
+        ".....##..##.....",
+        ".....##..##.....",
+        "....###..###....",
+        "....###..###....",
+        "....#.####.#....",
+        "....##.##.##....",
+        ".....######.....",
+        ".......##.......",
+        ".......##.......",
+        ".....######.....",
+        "................",
+    ),
+    # Bootstrap fill (source: assets/icons/bootstrap/mic-fill.svg)
+    "bootstrap_fill": (
+        "................",
+        "......####......",
+        "......####......",
+        ".....######.....",
+        ".....######.....",
+        ".....######.....",
+        ".....######.....",
+        "....########....",
+        "....########....",
+        "....#.####.#....",
+        "....##.##.##....",
+        ".....######.....",
+        ".......##.......",
+        ".......##.......",
+        ".....######.....",
+        "................",
+    ),
+}
+
+
+def _draw_mask_icon(draw: ImageDraw.ImageDraw, x: int, y: int, size: int, color, rows: tuple[str, ...]) -> None:
+    s = max(14, int(size))
+    mask = Image.new("1", (16, 16), 0)
+    pix = mask.load()
+    for yy, row in enumerate(rows[:16]):
+        for xx, ch in enumerate(row[:16]):
+            if ch == "#":
+                pix[xx, yy] = 1
+    if s != 16:
+        mask = mask.resize((s, s), Image.NEAREST)
+    draw.bitmap((int(x), int(y)), mask, fill=color)
+
+
+def _normalize_mic_style(style: str) -> str:
+    key = str(style or "").strip().lower()
+    key = _MIC_STYLE_ALIASES.get(key, key)
+    if key not in _MIC_ICON_MASKS_16:
+        return "tabler_outline"
+    return key
+
+
+def _resolve_voice_mic_style(theme: dict, *, phase_label: str, active: bool) -> str:
+    mode = str((theme or {}).get("voice_zone_mic_mode", "tabler_state") or "tabler_state").strip().lower()
+    if mode in ("tabler_state", "auto_tabler", "stateful", "auto"):
+        if not active:
+            return "tabler_outline"
+        if phase_label == "LISTENING":
+            return "tabler_filled"
+        if phase_label in ("PROCESSING", "CONFIRM"):
+            return "tabler_half"
+        return "tabler_outline"
+    raw_style = str((theme or {}).get("voice_zone_mic_style", "tabler_outline") or "tabler_outline")
+    return _normalize_mic_style(raw_style)
+
+
+def _draw_mic_icon(draw: ImageDraw.ImageDraw, x: int, y: int, size: int, color, *, style: str = "tabler_outline") -> None:
+    """
+    Draw a 1-bit-friendly microphone icon silhouette.
+    Styles map to masks derived from open-source SVG icon families.
+    """
+    key = _normalize_mic_style(style)
+    rows = _MIC_ICON_MASKS_16.get(key) or _MIC_ICON_MASKS_16["tabler_outline"]
+    _draw_mask_icon(draw, x, y, size, color, rows)
+
+
+def _voice_action_prompt(tool_name: str) -> str:
+    tool = str(tool_name or "").strip().lower()
+    if tool == "shopping_add_item":
+        return "Add to shopping list"
+    if tool == "shopping_remove_item":
+        return "Remove from shopping list"
+    if tool == "shopping_clear_all":
+        return "Clear shopping list"
+    if tool == "inventory_log_event":
+        return "Update inventory"
+    if tool == "inventory_set_expiry":
+        return "Set expiry"
+    if tool == "inventory_clear_all":
+        return "Clear inventory"
+    if tool == "timer_set":
+        return "Set timer"
+    if tool == "memo_add":
+        return "Add memo"
+    if tool == "no_action":
+        return "No action"
+    return "Do this"
+
+
+def _voice_tool_from_action_text(action_text: str) -> str:
+    txt = str(action_text or "").strip().lower()
+    if not txt:
+        return ""
+    head = txt.split("(", 1)[0].strip()
+    if not head:
+        return ""
+    return head.split()[0].strip()
+
+
+def _voice_short_result_text(text: str) -> str:
+    txt = str(text or "").strip().replace("\n", " ")
+    if not txt:
+        return ""
+    txt = txt.split(";", 1)[0].strip()
+    low = txt.lower()
+    if "non-actionable" in low or low.startswith("no action:") or low.startswith("skipped:"):
+        return "No change"
+    if low.startswith("added to shopping:"):
+        item = txt.split(":", 1)[1].strip() if ":" in txt else ""
+        return f"Added {item}".strip()
+    if low.startswith("removed from shopping:"):
+        item = txt.split(":", 1)[1].strip() if ":" in txt else ""
+        return f"Removed {item}".strip()
+    if low.startswith("removed from inventory:"):
+        item = txt.split(":", 1)[1].strip() if ":" in txt else ""
+        return f"Removed {item}".strip()
+    if low.startswith("cleared shopping list"):
+        return "Shopping cleared"
+    if low.startswith("cleared inventory"):
+        return "Inventory cleared"
+    if low.startswith("shopping list already empty"):
+        return "Already empty"
+    if low.startswith("inventory already empty"):
+        return "Already empty"
+    return _voice_preview_text(txt, max_chars=20)
+
+
+def _voice_preview_text(text: str, *, max_chars: int = 22) -> str:
+    txt = " ".join(str(text or "").split())
+    if not txt:
+        return ""
+    if len(txt) <= max_chars:
+        return txt
+    if max_chars <= 3:
+        return txt[:max_chars]
+    return txt[: max_chars - 3].rstrip() + "..."
+
+
+def _voice_summary_text(state: AppState, phase_label: str, msg: str, *, active: bool) -> str:
+    fields = _parse_voice_message_fields(msg)
+    heard = str(fields.get("heard") or "").strip()
+    action_text = str(fields.get("action") or "").strip()
+    result = str(fields.get("result") or "").strip()
+    other = [str(x).strip() for x in (fields.get("other") or []) if str(x).strip()]
+
+    if not active or phase_label == "READY":
+        return "Hold to talk"
+    if phase_label == "LISTENING":
+        return "Go ahead..."
+    if phase_label == "PROCESSING":
+        if heard:
+            return f"Heard: {_voice_preview_text(heard, max_chars=14)}"
+        return "On it..."
+
+    tool = ""
+    if phase_label == "CONFIRM":
+        tool = str(state.ui.voice_confirm_tool or "").strip().lower()
+    if not tool:
+        tool = _voice_tool_from_action_text(action_text)
+
+    heard_preview = _voice_preview_text(heard, max_chars=14)
+
+    if phase_label == "CONFIRM":
+        return f"{_voice_action_prompt(tool)}? Enter"
+
+    txt = result or (other[0] if other else str(msg or "").strip())
+    outcome = _voice_short_result_text(txt) if txt else ""
+
+    if phase_label == "ERROR":
+        return "Didn't catch that"
+    if phase_label == "SKIPPED":
+        return "No change"
+    if phase_label == "DONE":
+        if outcome:
+            return outcome
+        if heard_preview:
+            return f"Heard: {heard_preview}"
+        return "Done"
+
+    if outcome:
+        return outcome
+    if heard_preview:
+        return f"Heard: {heard_preview}"
+    return "Hold to talk"
+
+
+def _ellipsize_text(draw: ImageDraw.ImageDraw, text: str, *, font, max_width: float) -> str:
+    txt = " ".join(str(text or "").split())
+    if not txt:
+        return ""
+    if max_width <= 0:
+        return ""
+    if draw.textlength(txt, font=font) <= max_width:
+        return txt
+    ell = "..."
+    ell_w = draw.textlength(ell, font=font)
+    if ell_w >= max_width:
+        return ell
+    lo = 0
+    hi = len(txt)
+    best = ""
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        cand = txt[:mid].rstrip() + ell
+        if draw.textlength(cand, font=font) <= max_width:
+            best = cand
+            lo = mid + 1
+        else:
+            hi = mid - 1
+    return best or ell
+
+
+def _center_text_y(draw: ImageDraw.ImageDraw, text: str, *, font, top: int, height: int) -> int:
+    if height <= 0:
+        return int(top)
+    try:
+        b = draw.textbbox((0, 0), str(text or ""), font=font)
+        text_h = max(1, int(b[3] - b[1]))
+        return int(top + (height - text_h) // 2 - int(b[1]))
+    except Exception:
+        return int(top + max(0, (height - int(getattr(font, "size", 12))) // 2))
+
+
 def _draw_voice_overlay(image, state: AppState, fonts, theme: dict) -> None:
-    if not bool(state.ui.voice_active):
-        return
+    now = time.time()
+    pending_confirm = bool(state.ui.voice_confirm_tool) and float(state.ui.voice_confirm_due_at or 0.0) > now
+    active = bool(state.ui.voice_active) or pending_confirm
+
+    variant = str((theme or {}).get("home_variant") or "kitchen").strip().lower()
+    show_idle_home_zone = bool(theme.get("voice_zone_show_idle_home", True))
+    if not active:
+        if not show_idle_home_zone:
+            return
+        if state.ui.screen != Screen.HOME or variant != "kitchen":
+            return
+
+    phase = str(state.ui.voice_phase or "idle").strip().lower()
+    msg = str(state.ui.voice_message or "").strip()
+    if pending_confirm and phase != "confirm":
+        phase = "confirm"
+        if not msg:
+            tool_name = str(state.ui.voice_confirm_tool or "").strip().replace("_", " ")
+            msg = f"Press click / enter to confirm {tool_name or 'action'}"
 
     draw = ImageDraw.Draw(image)
     w, h = image.size
 
     ink = theme.get("ink", 0)
     card = theme.get("card", 255)
-    border = theme.get("border", ink)
     muted = theme.get("muted", ink)
 
-    box_w = min(560, max(360, int(w * 0.62)))
-    box_h = min(220, max(176, int(h * 0.38)))
-    x0 = (w - box_w) // 2
-    y0 = (h - box_h) // 2
-    x1 = x0 + box_w
-    y1 = y0 + box_h
+    margin = int(theme.get("voice_zone_margin", 14) or 14)
+    zone_w = int(theme.get("voice_zone_width", min(380, max(300, int(w * 0.46)))) or 340)
+    zone_w = max(220, min(zone_w, max(220, w - margin * 2)))
+    lane_h = int(theme.get("voice_zone_lane_h", 29) or 29)
+    icon_size = int(theme.get("voice_zone_icon_size", 18) or 18)
+    icon_nudge_y = int(theme.get("voice_zone_icon_nudge_y", -1) or -1)
+    text_nudge_y = int(theme.get("voice_zone_text_nudge_y", 0) or 0)
 
-    draw.rounded_rectangle(
-        (x0, y0, x1, y1),
-        radius=14,
-        outline=border,
-        width=3,
-        fill=card,
-    )
+    phase_label = _voice_zone_status_label(phase, msg)
+    mic_style = _resolve_voice_mic_style(theme, phase_label=phase_label, active=active)
+    zone_h = lane_h
 
-    title = _voice_overlay_title(state.ui.voice_phase)
-    msg = str(state.ui.voice_message or "").strip()
-    title_font = fonts.get("inter_black", 32)
-    msg_font = fonts.get("inter_semibold", 18)
-    hint_font = fonts.get("inter_regular", 14)
+    x0 = margin
+    y1 = h - margin
+    y0 = max(margin, y1 - zone_h)
+    x1 = x0 + zone_w
 
-    tw = draw.textlength(title, font=title_font)
-    draw.text((x0 + (box_w - tw) / 2, y0 + 28), title, font=title_font, fill=ink)
+    # Single-line rail: fixed height and width keep future partial-refresh region stable.
+    draw.rectangle((x0, y0 - 1, x1, y1 + 1), fill=card, outline=None)
 
-    if msg:
-        lines = _voice_wrap_message(msg, max_chars=44, max_lines=3)
-        base_y = y0 + 82
-        line_h = 24
-        for i, line in enumerate(lines):
-            mw = draw.textlength(line, font=msg_font)
-            draw.text((x0 + (box_w - mw) / 2, base_y + i * line_h), line, font=msg_font, fill=muted)
+    icon_x = x0 + 2
+    icon_y = y0 + max(0, (zone_h - icon_size) // 2) + icon_nudge_y
+    _draw_mic_icon(draw, icon_x, icon_y, icon_size, ink, style=mic_style)
 
-    if state.ui.voice_phase in ("recording", "processing"):
-        hint = "PLEASE WAIT"
-    elif state.ui.voice_phase == "confirm":
-        hint = "PRESS CLICK / ENTER"
-    else:
-        hint = " "
-    hw = draw.textlength(hint, font=hint_font)
-    draw.text((x0 + (box_w - hw) / 2, y1 - 30), hint, font=hint_font, fill=muted)
+    state_font = fonts.get("inter_bold", 13)
+    tx = icon_x + icon_size + 7
+    state_text = _voice_summary_text(state, phase_label, msg, active=active)
+    max_text_w = max(0.0, (x1 - 2) - tx)
+    state_text = _ellipsize_text(draw, state_text, font=state_font, max_width=max_text_w)
+    ty = _center_text_y(draw, state_text, font=state_font, top=y0, height=zone_h) + text_nudge_y
+    draw.text((tx, ty), state_text, font=state_font, fill=ink)
 
 
 def _to_render_data(state: AppState) -> dict:

--- a/assets/icons/bootstrap/LICENSE.txt
+++ b/assets/icons/bootstrap/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2019-2024 The Bootstrap Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/assets/icons/bootstrap/mic-fill.svg
+++ b/assets/icons/bootstrap/mic-fill.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-mic-fill" viewBox="0 0 16 16">
+  <path d="M5 3a3 3 0 0 1 6 0v5a3 3 0 0 1-6 0z"/>
+  <path d="M3.5 6.5A.5.5 0 0 1 4 7v1a4 4 0 0 0 8 0V7a.5.5 0 0 1 1 0v1a5 5 0 0 1-4.5 4.975V15h3a.5.5 0 0 1 0 1h-7a.5.5 0 0 1 0-1h3v-2.025A5 5 0 0 1 3 8V7a.5.5 0 0 1 .5-.5"/>
+</svg>

--- a/assets/icons/bootstrap/mic.svg
+++ b/assets/icons/bootstrap/mic.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-mic" viewBox="0 0 16 16">
+  <path d="M3.5 6.5A.5.5 0 0 1 4 7v1a4 4 0 0 0 8 0V7a.5.5 0 0 1 1 0v1a5 5 0 0 1-4.5 4.975V15h3a.5.5 0 0 1 0 1h-7a.5.5 0 0 1 0-1h3v-2.025A5 5 0 0 1 3 8V7a.5.5 0 0 1 .5-.5"/>
+  <path d="M10 8a2 2 0 1 1-4 0V3a2 2 0 1 1 4 0zM8 0a3 3 0 0 0-3 3v5a3 3 0 0 0 6 0V3a3 3 0 0 0-3-3"/>
+</svg>

--- a/assets/icons/heroicons/16-solid-microphone.svg
+++ b/assets/icons/heroicons/16-solid-microphone.svg
@@ -1,0 +1,9 @@
+<!--
+Source: Heroicons (Tailwind Labs), MIT License
+Repo: https://github.com/tailwindlabs/heroicons
+File: optimized/16/solid/microphone.svg
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" data-slot="icon">
+  <path d="M8 1a2 2 0 0 0-2 2v4a2 2 0 1 0 4 0V3a2 2 0 0 0-2-2Z"/>
+  <path d="M4.5 7A.75.75 0 0 0 3 7a5.001 5.001 0 0 0 4.25 4.944V13.5h-1.5a.75.75 0 0 0 0 1.5h4.5a.75.75 0 0 0 0-1.5h-1.5v-1.556A5.001 5.001 0 0 0 13 7a.75.75 0 0 0-1.5 0 3.5 3.5 0 1 1-7 0Z"/>
+</svg>

--- a/assets/icons/heroicons/LICENSE.txt
+++ b/assets/icons/heroicons/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Tailwind Labs, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/assets/icons/lucide/LICENSE.txt
+++ b/assets/icons/lucide/LICENSE.txt
@@ -1,0 +1,39 @@
+ISC License
+
+Copyright (c) for portions of Lucide are held by Cole Bemis 2013-2026 as part of Feather (MIT). All other copyright (c) for Lucide are held by Lucide Contributors 2026.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+---
+
+The MIT License (MIT) (for portions derived from Feather)
+
+Copyright (c) 2013-2026 Cole Bemis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/assets/icons/lucide/mic.svg
+++ b/assets/icons/lucide/mic.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 19v3" />
+  <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+  <rect x="9" y="2" width="6" height="13" rx="3" />
+</svg>

--- a/assets/icons/tabler/LICENSE.txt
+++ b/assets/icons/tabler/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-2026 Paweł Kuna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/assets/icons/tabler/microphone-filled.svg
+++ b/assets/icons/tabler/microphone-filled.svg
@@ -1,0 +1,13 @@
+<!--
+unicode: "fe0f"
+version: "3.0"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="currentColor"
+>
+  <path d="M19 9a1 1 0 0 1 1 1a8 8 0 0 1 -6.999 7.938l-.001 2.062h3a1 1 0 0 1 0 2h-8a1 1 0 0 1 0 -2h3v-2.062a8 8 0 0 1 -7 -7.938a1 1 0 1 1 2 0a6 6 0 0 0 12 0a1 1 0 0 1 1 -1m-7 -8a4 4 0 0 1 4 4v5a4 4 0 1 1 -8 0v-5a4 4 0 0 1 4 -4" />
+</svg>

--- a/assets/icons/tabler/microphone-outline.svg
+++ b/assets/icons/tabler/microphone-outline.svg
@@ -1,0 +1,22 @@
+<!--
+tags: [record, sound, listen, microphone, content, entertainment, multimedia, broadcast, audio]
+category: Media
+version: "1.0"
+unicode: "eaf0"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M9 5a3 3 0 0 1 3 -3a3 3 0 0 1 3 3v5a3 3 0 0 1 -3 3a3 3 0 0 1 -3 -3l0 -5" />
+  <path d="M5 10a7 7 0 0 0 14 0" />
+  <path d="M8 21l8 0" />
+  <path d="M12 17l0 4" />
+</svg>

--- a/docs/VOICE_UI_UX_V1_EPAPER.md
+++ b/docs/VOICE_UI_UX_V1_EPAPER.md
@@ -1,0 +1,89 @@
+# Voice UI/UX v1 (E-Paper, Hardware-Aware)
+
+## What Changed
+
+- Replaced large centered overlay with a fixed left-bottom `Mic/Voice Zone`.
+- Kept the voice area single-line, bounded, and geometry-stable.
+- Updated copy to a conversational sequence (less industrial status wording).
+- Added state-aware mic icon behavior tuned for 1-bit readability.
+
+## Voice Zone Pattern
+
+- Position: fixed left-bottom lane.
+- Height: single line (`voice_zone_lane_h`).
+- Width: bounded (`voice_zone_width`).
+- Text: one short sentence only (no multi-line expansion).
+- Goal: stable region for future dirty-region/partial-refresh routing.
+
+## Copy Flow (Current)
+
+- `READY` -> `Hold to talk`
+- `LISTENING` -> `Go ahead...`
+- `PROCESSING` -> `Heard: <short>`
+- `CONFIRM` -> `<action>? Enter`
+- `DONE` -> short result (for example `Added Milk`)
+- `SKIPPED` -> `No change`
+- `ERROR` -> `Didn't catch that`
+
+Design intent:
+
+- Keep flow conversational and continuous (not a state-machine broadcast).
+- Preserve user confidence via short transcript preview + clear outcome.
+- Keep destructive confirmation explicit without modal interruption.
+
+## Mic Icon Strategy
+
+- Default mode: `voice_zone_mic_mode = tabler_state`
+  - `READY / DONE` -> `tabler_outline`
+  - `LISTENING` -> `tabler_filled`
+  - `PROCESSING / CONFIRM` -> `tabler_half`
+- Manual mode remains available (`voice_zone_mic_mode = manual`) via `voice_zone_mic_style`.
+
+Available icon families in simulator gallery:
+
+- `heroicons_solid`
+- `heroicons_outline`
+- `tabler_outline`
+- `tabler_half`
+- `tabler_filled`
+- `bootstrap_outline`
+- `bootstrap_fill`
+
+Sources and licenses:
+
+- `assets/icons/heroicons/*`
+- `assets/icons/tabler/*`
+- `assets/icons/bootstrap/*`
+- `assets/icons/lucide/*`
+
+## Confirm UX (Destructive Actions)
+
+- Confirm is displayed in the fixed voice zone (no full-screen blocking popup).
+- Confirm text follows product copy style: `<action>? Enter`.
+- Confirm stays visible for the full pending-confirm window.
+- Simulator hold duration is extended to cover pending confirm timeout.
+
+## E-Paper Refresh Strategy (v1)
+
+Current implementation:
+
+- Voice zone is layout-ready for bounded refresh.
+- Board path still uses full-screen refresh for reliability:
+  - `tools/run_epaper_console.py` -> `display_image(...)`
+
+Why v1 still full-screen:
+
+- Lower risk and simpler failure modes for current hardware path.
+- Prevent partial-refresh artifact regressions while UX is stabilizing.
+
+Planned direction:
+
+- Hybrid strategy: partial for small stable regions (voice lane/focus cues), full refresh for page-scale changes and periodic ghost cleanup.
+
+## Simulator + Board Compatibility
+
+- Shared renderer: `app/ui/app.py` (`render_app` and voice lane drawing).
+- Simulator path: `tools/sim_app_tk.py`.
+- Board path: `tools/run_epaper_console.py`.
+
+Both paths consume `state.ui.voice_*`, so behavior is MCU-migratable at the state-contract level.

--- a/tests/test_voice_ui_copy.py
+++ b/tests/test_voice_ui_copy.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import unittest
+
+from app.core.state import AppState, DashboardModel
+from app.ui.app import _voice_summary_text
+
+
+class VoiceUiCopyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.state = AppState(model=DashboardModel())
+
+    def test_ready_copy(self) -> None:
+        got = _voice_summary_text(self.state, "READY", "", active=False)
+        self.assertEqual(got, "Hold to talk")
+
+    def test_listening_copy(self) -> None:
+        got = _voice_summary_text(self.state, "LISTENING", "", active=True)
+        self.assertEqual(got, "Go ahead...")
+
+    def test_processing_shows_heard_preview(self) -> None:
+        msg = "Heard: add milk to shopping list"
+        got = _voice_summary_text(self.state, "PROCESSING", msg, active=True)
+        self.assertTrue(got.startswith("Heard: add milk"))
+        self.assertTrue(got.endswith("..."))
+
+    def test_confirm_shows_natural_action_prompt(self) -> None:
+        self.state.ui.voice_confirm_tool = "shopping_clear_all"
+        got = _voice_summary_text(self.state, "CONFIRM", "", active=True)
+        self.assertEqual(got, "Clear shopping list? Enter")
+
+    def test_done_result_is_humanized(self) -> None:
+        msg = "Result: Added to shopping: Milk"
+        got = _voice_summary_text(self.state, "DONE", msg, active=True)
+        self.assertEqual(got, "Added Milk")
+
+    def test_skipped_copy(self) -> None:
+        msg = "Result: Skipped: no actionable command"
+        got = _voice_summary_text(self.state, "SKIPPED", msg, active=True)
+        self.assertEqual(got, "No change")
+
+    def test_error_copy(self) -> None:
+        got = _voice_summary_text(self.state, "ERROR", "Result: backend timeout", active=True)
+        self.assertEqual(got, "Didn't catch that")
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tools/sim_app_tk.py
+++ b/tools/sim_app_tk.py
@@ -13,7 +13,7 @@ from tkinter import ttk
 import re
 from datetime import datetime
 
-from PIL import Image, ImageTk
+from PIL import Image, ImageDraw, ImageTk
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if REPO_ROOT not in sys.path:
@@ -25,7 +25,7 @@ from app.render.panel import build_panel_theme, quantize_for_panel
 from app.shared.env import load_repo_dotenv
 from app.shared.fonts import FontBook
 from app.shared.paths import find_repo_root
-from app.ui.app import render_app
+from app.ui.app import render_app, _draw_mic_icon, _normalize_mic_style
 from app.voice import (
     VoiceClientError,
     apply_voice_action,
@@ -530,6 +530,8 @@ class Simulator(tk.Tk):
         self.panel_gamma = tk.DoubleVar(value=float(self.theme.get("panel_gamma", 1.0)))
         self.panel_dither = tk.BooleanVar(value=bool(self.theme.get("panel_dither", False)))
         self.badge_style = tk.StringVar(value=str(self.theme.get("b_badge_style", "text")))
+        self.voice_mic_mode = tk.StringVar(value=str(self.theme.get("voice_zone_mic_mode", "tabler_state")))
+        self.voice_mic_style = tk.StringVar(value=str(self.theme.get("voice_zone_mic_style", "tabler_outline")))
         self.voice_api_url = tk.StringVar(value=os.environ.get("VOICE_SIM_API_URL", os.environ.get("VOICE_API_URL", "")))
         self.voice_timeout_s = tk.DoubleVar(value=float(os.environ.get("VOICE_TIMEOUT_S", "12")))
         self.voice_audio_max_sec = tk.IntVar(value=max(1, int(os.environ.get("VOICE_MAX_SEC", "6"))))
@@ -578,6 +580,30 @@ class Simulator(tk.Tk):
             state="readonly",
             width=16,
         ).grid(row=0, column=10, padx=(0, 6), sticky="w")
+        ttk.Label(self.controls, text="Mic Style").grid(row=0, column=11, padx=(10, 6), sticky="w")
+        ttk.Combobox(
+            self.controls,
+            textvariable=self.voice_mic_style,
+            values=(
+                "heroicons_solid",
+                "heroicons_outline",
+                "tabler_outline",
+                "tabler_half",
+                "tabler_filled",
+                "bootstrap_outline",
+                "bootstrap_fill",
+            ),
+            state="readonly",
+            width=16,
+        ).grid(row=0, column=12, padx=(0, 6), sticky="w")
+        ttk.Label(self.controls, text="Mic Mode").grid(row=0, column=13, padx=(8, 6), sticky="w")
+        ttk.Combobox(
+            self.controls,
+            textvariable=self.voice_mic_mode,
+            values=("tabler_state", "manual"),
+            state="readonly",
+            width=12,
+        ).grid(row=0, column=14, padx=(0, 6), sticky="w")
         ttk.Label(self.controls, text="Voice API").grid(row=1, column=0, padx=(0, 6), pady=(8, 0), sticky="w")
         ttk.Entry(self.controls, textvariable=self.voice_api_url, width=42).grid(row=1, column=1, columnspan=5, pady=(8, 0), sticky="ew")
         ttk.Label(self.controls, text="Max").grid(row=1, column=6, padx=(6, 4), pady=(8, 0), sticky="w")
@@ -596,6 +622,9 @@ class Simulator(tk.Tk):
         self.mic_combo.grid(row=2, column=1, columnspan=3, padx=(0, 8), pady=(8, 0), sticky="w")
         self.mic_combo.bind("<<ComboboxSelected>>", self._on_mic_selected)
         ttk.Button(self.controls, text="Refresh Mic", command=self._refresh_ffmpeg_devices).grid(row=2, column=4, pady=(8, 0), sticky="w")
+        ttk.Label(self.controls, text="Mic Gallery").grid(row=3, column=0, padx=(0, 6), pady=(8, 0), sticky="nw")
+        self.mic_gallery = ttk.Label(self.controls)
+        self.mic_gallery.grid(row=3, column=1, columnspan=12, padx=(0, 6), pady=(8, 0), sticky="w")
 
         self.preview = ttk.Label(self)
         self.preview.grid(row=1, column=0, sticky="nsew", padx=10, pady=10)
@@ -632,17 +661,52 @@ class Simulator(tk.Tk):
         self.bind_all("<KeyPress-space>", self._on_space_press)
         self.bind_all("<KeyRelease-space>", self._on_space_release)
 
-        for v in (self.preview_mode, self.panel_threshold, self.panel_muted, self.panel_gamma, self.badge_style):
+        for v in (
+            self.preview_mode,
+            self.panel_threshold,
+            self.panel_muted,
+            self.panel_gamma,
+            self.badge_style,
+            self.voice_mic_mode,
+            self.voice_mic_style,
+        ):
             v.trace_add("write", lambda *_: self._render())
 
+        self._last_tick_render_sig = None
         self.after(100, self._tick)
         self._render()
 
     def _tick(self):
+        before_sig = self._tick_render_sig()
         expire_pending_voice_confirmation(self.state)
         self.state = reduce(self.state, Tick(), theme=self.theme)
-        self._render()
+        after_sig = self._tick_render_sig()
+        if after_sig != before_sig or after_sig != self._last_tick_render_sig:
+            self._render()
+            self._last_tick_render_sig = after_sig
         self.after(100, self._tick)
+
+    def _tick_render_sig(self):
+        ui = self.state.ui
+        return (
+            ui.screen.value,
+            int(ui.focused_index or 0),
+            int(ui.page or 0),
+            bool(ui.idle),
+            str(getattr(ui.widget_mode, "value", ui.widget_mode)),
+            int(ui.timer_seconds or 0),
+            bool(ui.timer_running),
+            bool(ui.voice_active),
+            str(ui.voice_phase or ""),
+            str(ui.voice_message or ""),
+            str(ui.voice_confirm_tool or ""),
+            bool(ui.pending_reorder),
+            int(ui.reminders_version or 0),
+            int(ui.memo_index or 0),
+            int(ui.weather_day_index or 0),
+            bool(self.voice_busy),
+            bool(self.voice_recording),
+        )
 
     def _dispatch(self, ev):
         if isinstance(ev, Click):
@@ -1101,7 +1165,11 @@ class Simulator(tk.Tk):
             before_snap=before_snap,
             after_snap=after_snap,
         )
-        self._set_voice_overlay(result.status, shown, hold_s=4.0)
+        hold_s = 4.0
+        if str(result.status or "").strip().lower() == "confirm":
+            remaining_confirm_s = max(0.0, float(self.state.ui.voice_confirm_due_at or 0.0) - time.time())
+            hold_s = max(hold_s, remaining_confirm_s + 0.2)
+        self._set_voice_overlay(result.status, shown, hold_s=hold_s)
         self._render()
 
     def _voice_error(self, msg: str) -> None:
@@ -1119,6 +1187,13 @@ class Simulator(tk.Tk):
         if badge_style not in ("text", "text_focus_invert", "outline", "invert", "focus_invert"):
             badge_style = "text"
         self.theme["b_badge_style"] = badge_style
+        mic_mode = str(self.voice_mic_mode.get() or "tabler_state").strip().lower()
+        if mic_mode not in ("tabler_state", "manual"):
+            mic_mode = "tabler_state"
+        self.theme["voice_zone_mic_mode"] = mic_mode
+        mic_style = _normalize_mic_style(str(self.voice_mic_style.get() or "tabler_outline"))
+        self.theme["voice_zone_mic_style"] = mic_style
+        self._render_mic_gallery(selected=mic_style)
 
         bg = self.theme.get("bg", (229, 229, 229))
         color_img = Image.new("RGB", (w, h), bg if isinstance(bg, tuple) else (229, 229, 229))
@@ -1156,11 +1231,51 @@ class Simulator(tk.Tk):
                 f"screen={ui.screen.value} focus={ui.focused_index} page={ui.page} idle={ui.idle} "
                 f"pending_reorder={ui.pending_reorder} mode={mode} th={threshold} muted={muted} "
                 f"gamma={gamma:.2f} dither={dither} badge_style={badge_style} "
+                f"mic_mode={mic_mode} mic_style={mic_style} "
                 f"focus_style={self.theme.get('b_right_focus_style', 'row_box')} fonts_ok={font_ok} "
                 f"voice={ui.voice_phase}:{voice_source} recorder={recorder} "
                 f"last_tool={self.last_tool or '-'} heard={self.last_heard or '-'}"
             )
         )
+
+    def _render_mic_gallery(self, *, selected: str) -> None:
+        styles = [
+            ("heroicons_solid", "Hero S"),
+            ("heroicons_outline", "Hero O"),
+            ("tabler_outline", "Tabler O"),
+            ("tabler_half", "Tabler H"),
+            ("tabler_filled", "Tabler F"),
+            ("bootstrap_outline", "BS O"),
+            ("bootstrap_fill", "BS F"),
+        ]
+        tile_w = 96
+        tile_h = 82
+        gap = 8
+        pad = 6
+        img_w = pad * 2 + len(styles) * tile_w + (len(styles) - 1) * gap
+        img_h = tile_h + pad * 2
+        img = Image.new("RGB", (img_w, img_h), (246, 246, 246))
+        draw = ImageDraw.Draw(img)
+        for i, (key, label) in enumerate(styles):
+            x = pad + i * (tile_w + gap)
+            y = pad
+            is_sel = (key == selected)
+            draw.rounded_rectangle(
+                (x, y, x + tile_w, y + tile_h),
+                radius=6,
+                outline=(0, 0, 0) if is_sel else (190, 190, 190),
+                width=2 if is_sel else 1,
+                fill=(255, 255, 255),
+            )
+            # Top: actual-size line sample (close to board usage).
+            _draw_mic_icon(draw, x + 7, y + 8, 16, (0, 0, 0), style=key)
+            draw.text((x + 28, y + 8), "READY", fill=(0, 0, 0), font=self.fonts.get("inter_semibold", 12))
+            draw.line((x + 7, y + 28, x + tile_w - 7, y + 28), fill=(205, 205, 205), width=1)
+            # Bottom: zoomed icon for silhouette comparison.
+            _draw_mic_icon(draw, x + 34, y + 34, 26, (0, 0, 0), style=key)
+            draw.text((x + 8, y + 63), label, fill=(0, 0, 0), font=self.fonts.get("inter_semibold", 11))
+        self._mic_gallery_photo = ImageTk.PhotoImage(img)
+        self.mic_gallery.configure(image=self._mic_gallery_photo)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace modal voice overlay with a fixed single-line voice/mic zone anchored at left-bottom
- add state-aware mic icon behavior (`tabler_state`) with `tabler_outline` / `tabler_half` / `tabler_filled` and keep manual style selection in simulator
- improve voice copy flow for hardware UX: `Hold to talk -> Go ahead... -> Heard: ... -> <action>? Enter -> short result`
- add simulator mic gallery and controls for mic mode/style
- add open-source mic SVG sources + license files (Heroicons/Tabler/Bootstrap/Lucide)
- document refresh strategy/tradeoffs and UX behavior in `docs/VOICE_UI_UX_V1_EPAPER.md`
- add tests for voice UI copy mapping (`tests/test_voice_ui_copy.py`)

## Validation
- `python3 -m py_compile app/ui/app.py tools/sim_app_tk.py tests/test_voice_ui_copy.py`
- `PYTHONPATH=. pytest -q tests/test_voice_ui_copy.py tests/test_voice_actions.py`

## Notes
- full `pytest` still collects hardware/vendor example suites that require Waveshare binaries/devices; this PR validates the app-level suites above.
- refs #16
