### PR TITLE
Add voice backend Render deployment baseline

### DIFF
--- a/app/voice/client.py
+++ b/app/voice/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+import os
 from typing import Any
 from urllib import request, error
 
@@ -19,6 +20,7 @@ def interpret_audio_via_backend(
     meta: VoiceRequestMeta,
     timeout_s: float = 20.0,
     board_context: dict[str, Any] | None = None,
+    auth_token: str | None = None,
 ) -> dict[str, Any]:
     if not api_url:
         raise VoiceClientError("VOICE_API_URL is not configured")
@@ -40,7 +42,7 @@ def interpret_audio_via_backend(
     req = request.Request(
         api_url,
         data=body,
-        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        headers=_build_request_headers(auth_token=auth_token),
         method="POST",
     )
 
@@ -67,6 +69,7 @@ def interpret_transcript_via_backend(
     meta: VoiceRequestMeta,
     timeout_s: float = 20.0,
     board_context: dict[str, Any] | None = None,
+    auth_token: str | None = None,
 ) -> dict[str, Any]:
     if not api_url:
         raise VoiceClientError("VOICE_API_URL is not configured")
@@ -85,7 +88,7 @@ def interpret_transcript_via_backend(
     req = request.Request(
         api_url,
         data=body,
-        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        headers=_build_request_headers(auth_token=auth_token),
         method="POST",
     )
 
@@ -103,3 +106,11 @@ def interpret_transcript_via_backend(
         raise VoiceClientError(f"network error: {e.reason}") from e
     except json.JSONDecodeError as e:
         raise VoiceClientError("backend returned invalid JSON") from e
+
+
+def _build_request_headers(*, auth_token: str | None) -> dict[str, str]:
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    token = str(auth_token if auth_token is not None else os.environ.get("VOICE_API_TOKEN", "")).strip()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import os
 import threading
 import time
 import unittest
+
+from fastapi.testclient import TestClient
 
 from backend.voice_api import app as voice_app
 
@@ -15,8 +18,12 @@ class VoiceApiAppCacheTests(unittest.TestCase):
         self._orig_max = voice_app._IDEMPOTENCY_CACHE_MAX_SIZE
         self._orig_wait_timeout = voice_app._IDEMPOTENCY_INFLIGHT_WAIT_TIMEOUT_S
         self._orig_interpret = voice_app.interpret_request_with_debug
+        self._orig_voice_api_token = os.environ.get("VOICE_API_TOKEN")
+        self._orig_log_transcript = os.environ.get("VOICE_API_LOG_TRANSCRIPT")
         voice_app._idempotency_cache.clear()
         voice_app._inflight_requests.clear()
+        os.environ.pop("VOICE_API_TOKEN", None)
+        os.environ.pop("VOICE_API_LOG_TRANSCRIPT", None)
 
     def tearDown(self) -> None:
         voice_app._idempotency_cache.clear()
@@ -27,6 +34,14 @@ class VoiceApiAppCacheTests(unittest.TestCase):
         voice_app._IDEMPOTENCY_CACHE_MAX_SIZE = self._orig_max
         voice_app._IDEMPOTENCY_INFLIGHT_WAIT_TIMEOUT_S = self._orig_wait_timeout
         voice_app.interpret_request_with_debug = self._orig_interpret
+        if self._orig_voice_api_token is None:
+            os.environ.pop("VOICE_API_TOKEN", None)
+        else:
+            os.environ["VOICE_API_TOKEN"] = self._orig_voice_api_token
+        if self._orig_log_transcript is None:
+            os.environ.pop("VOICE_API_LOG_TRANSCRIPT", None)
+        else:
+            os.environ["VOICE_API_LOG_TRANSCRIPT"] = self._orig_log_transcript
 
     def test_prune_idempotency_cache_evicts_expired_entries(self) -> None:
         voice_app._IDEMPOTENCY_CACHE_TTL_S = 10.0
@@ -137,6 +152,55 @@ class VoiceApiAppCacheTests(unittest.TestCase):
             transcript="hello",
         )
         self.assertEqual(req.locale, "en-US")
+
+    def test_health_endpoint_does_not_require_auth(self) -> None:
+        os.environ["VOICE_API_TOKEN"] = "shared-secret"
+        client = TestClient(voice_app.app)
+        resp = client.get("/health")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"status": "ok"})
+
+    def test_voice_interpret_rejects_missing_auth_when_token_is_configured(self) -> None:
+        os.environ["VOICE_API_TOKEN"] = "shared-secret"
+        client = TestClient(voice_app.app)
+        resp = client.post(
+            "/voice/interpret",
+            json={
+                "request_id": "voice-auth-missing",
+                "request_time": "2026-02-24T12:00:00+00:00",
+                "timezone": "UTC",
+                "locale": "en-US",
+                "transcript": "add milk",
+            },
+        )
+        self.assertEqual(resp.status_code, 401)
+        self.assertEqual(resp.json()["detail"], "missing_or_invalid_auth_token")
+
+    def test_voice_interpret_accepts_valid_bearer_token(self) -> None:
+        os.environ["VOICE_API_TOKEN"] = "shared-secret"
+        client = TestClient(voice_app.app)
+
+        def fake_interpret(req_dict):
+            return {
+                "action": {"tool": "shopping_add_item", "args": {"item_name": "milk"}},
+                "plan": {"actions": [{"tool": "shopping_add_item", "args": {"item_name": "milk"}}]},
+                "transcript": str(req_dict.get("transcript") or ""),
+            }
+
+        voice_app.interpret_request_with_debug = fake_interpret
+        resp = client.post(
+            "/voice/interpret",
+            headers={"Authorization": "Bearer shared-secret"},
+            json={
+                "request_id": "voice-auth-ok",
+                "request_time": "2026-02-24T12:00:00+00:00",
+                "timezone": "UTC",
+                "locale": "en-US",
+                "transcript": "add milk",
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["action"]["tool"], "shopping_add_item")
 
 
 if __name__ == "__main__":

--- a/backend/voice_api/Dockerfile
+++ b/backend/voice_api/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PORT=8000
+
+WORKDIR /app
+
+COPY backend/voice_api/requirements.txt ./backend/voice_api/requirements.txt
+RUN pip install --no-cache-dir -r backend/voice_api/requirements.txt
+
+COPY app ./app
+COPY backend ./backend
+COPY docs/prompt ./docs/prompt
+
+RUN useradd --create-home --shell /usr/sbin/nologin appuser \
+    && chown -R appuser:appuser /app
+
+USER appuser
+
+EXPOSE 8000
+
+CMD ["sh", "-c", "uvicorn backend.voice_api.app:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/backend/voice_api/README.md
+++ b/backend/voice_api/README.md
@@ -46,9 +46,13 @@ pip install -r backend/voice_api/requirements.txt
 ```bash
 export GOOGLE_API_KEY="<your-key>"
 export GEMINI_MODEL="gemini-2.5-flash"
+export VOICE_API_TOKEN="replace-with-shared-device-secret"
 # Optional: enable one extra low-risk repair pass after an initial no_action.
 # Default is off to avoid extra latency on normal requests.
-export VOICE_ENABLE_NO_ACTION_RETRY="1"
+export VOICE_ENABLE_NO_ACTION_RETRY="0"
+# Optional: include transcript text in app logs for debugging.
+# Default is off for hosted deployments.
+export VOICE_API_LOG_TRANSCRIPT="0"
 ```
 
 Or put variables in repo root `.env` (auto-loaded by backend and simulator).
@@ -59,11 +63,17 @@ Or put variables in repo root `.env` (auto-loaded by backend and simulator).
 uvicorn backend.voice_api.app:app --host 0.0.0.0 --port 8000 --reload
 ```
 
+Auth behavior:
+- `/health` is always open for platform health checks.
+- `/voice/interpret` requires `Authorization: Bearer <VOICE_API_TOKEN>` only when `VOICE_API_TOKEN` is configured.
+- Local dev can leave `VOICE_API_TOKEN` unset to keep the old no-auth workflow.
+
 ## 4) Test endpoint
 
 ```bash
 curl -X POST http://127.0.0.1:8000/voice/interpret \
   -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer ${VOICE_API_TOKEN}" \
   -d '{
     "request_id":"demo-1",
     "request_time":"2026-02-20T10:00:00+08:00",
@@ -77,22 +87,53 @@ curl -X POST http://127.0.0.1:8000/voice/interpret \
 
 Simulator:
 ```bash
-VOICE_SIM_API_URL="http://127.0.0.1:8000/voice/interpret" python3 tools/sim_app_tk.py
+VOICE_SIM_API_URL="http://127.0.0.1:8000/voice/interpret" \
+VOICE_SIM_API_TOKEN="${VOICE_API_TOKEN}" \
+python3 tools/sim_app_tk.py
 ```
 
 Pi runner:
 ```bash
-VOICE_API_URL="http://<server>:8000/voice/interpret" python3 tools/run_epaper_console.py
+VOICE_API_URL="http://<server>:8000/voice/interpret" \
+VOICE_API_TOKEN="${VOICE_API_TOKEN}" \
+python3 tools/run_epaper_console.py
+```
+
+Runner CLI equivalent:
+```bash
+python3 tools/run_epaper_console.py \
+  --voice-api-url "https://<your-service>.onrender.com/voice/interpret" \
+  --voice-api-token "${VOICE_API_TOKEN}"
+```
+
+## 6) Docker + Render
+- Docker image entrypoint: `backend/voice_api/Dockerfile`
+- Render blueprint: `render.yaml`
+- Full deploy/update/rollback/smoke-test runbook:
+  - `docs/VOICE_BACKEND_DEPLOYMENT_RENDER.md`
+
+Local Docker smoke test:
+```bash
+docker build -f backend/voice_api/Dockerfile -t fridge-ink-voice-api .
+docker run --rm -p 8000:8000 \
+  -e GOOGLE_API_KEY="${GOOGLE_API_KEY}" \
+  -e GEMINI_MODEL="${GEMINI_MODEL:-gemini-2.5-flash}" \
+  -e VOICE_API_TOKEN="${VOICE_API_TOKEN}" \
+  fridge-ink-voice-api
 ```
 
 ## Notes
 - Prompt source: `docs/prompt/voice_prompt_v1.md`
 - Tool schema source: `docs/prompt/voice_tools_schema_v1.json`
+- Health check endpoint: `GET /health`
 - `request_id` is idempotent within process memory (simple cache)
 - `VOICE_ENABLE_NO_ACTION_RETRY` is off by default.
   - When enabled, the backend may do one additional low-risk retry after an initial `no_action`.
   - This improves recovery for some colloquial phrasing, but it adds latency.
   - If we surface this outside env vars later, it should be a user/operator setting rather than the default path.
+- `VOICE_API_LOG_TRANSCRIPT` is off by default.
+  - Hosted logs still include request id, mode, locale, timezone, client, action summary, and duration.
+  - Enable transcript logging only for short-lived debugging.
 - Local correction KB (voice alias memory) path:
   - default: `backend/voice_api/data/correction_kb.json`
   - override: `VOICE_CORRECTION_KB_PATH=/abs/path/to/correction_kb.json`

--- a/backend/voice_api/app.py
+++ b/backend/voice_api/app.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import json
 import logging
 import os
+import secrets
 import threading
 import time
 from typing import Any
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Header, HTTPException, Request, status
 from pydantic import BaseModel, Field
 
 from app.shared.env import load_repo_dotenv
@@ -56,9 +57,15 @@ def health() -> dict[str, str]:
 
 
 @app.post("/voice/interpret", response_model=VoiceInterpretResponse)
-def voice_interpret(req: VoiceInterpretRequest) -> VoiceInterpretResponse:
+def voice_interpret(
+    req: VoiceInterpretRequest,
+    request: Request = None,
+    authorization: str | None = Header(default=None),
+) -> VoiceInterpretResponse:
+    started_at = time.perf_counter()
     req_dict = req.model_dump()
     req_id = str(req_dict.get("request_id") or "").strip()
+    _verify_voice_api_auth(req_id=req_id, authorization=authorization, request=request)
     inflight_entry: dict[str, Any] | None = None
     is_leader = False
 
@@ -73,11 +80,17 @@ def voice_interpret(req: VoiceInterpretRequest) -> VoiceInterpretResponse:
                     _inflight_requests[req_id] = inflight_entry
                     is_leader = True
         if cached is not None:
+            duration_ms = _elapsed_ms(started_at)
             _log.info(
-                "voice_interpret cached request_id=%s action=%s transcript=%s",
+                "voice_interpret request_id=%s status=cached mode=%s locale=%s timezone=%s client=%s action=%s duration_ms=%s transcript=%s",
                 req_id,
+                _request_mode(req_dict),
+                _clip_log_text(str(req_dict.get("locale") or "")),
+                _clip_log_text(str(req_dict.get("timezone") or "")),
+                _request_client(request),
                 _summarize_action(dict(cached.get("action") or {})),
-                _clip_log_text(str(cached.get("transcript") or "")),
+                duration_ms,
+                _maybe_log_transcript(str(cached.get("transcript") or "")),
             )
             return VoiceInterpretResponse(
                 action=dict(cached.get("action") or {}),
@@ -101,11 +114,17 @@ def voice_interpret(req: VoiceInterpretRequest) -> VoiceInterpretResponse:
             action = dict(inflight_entry.get("action") or {})
             plan = dict(inflight_entry.get("plan") or {}) if isinstance(inflight_entry.get("plan"), dict) else None
             transcript = str(inflight_entry.get("transcript") or "")
+            duration_ms = _elapsed_ms(started_at)
             _log.info(
-                "voice_interpret inflight-reuse request_id=%s action=%s transcript=%s",
+                "voice_interpret request_id=%s status=inflight_reuse mode=%s locale=%s timezone=%s client=%s action=%s duration_ms=%s transcript=%s",
                 req_id,
+                _request_mode(req_dict),
+                _clip_log_text(str(req_dict.get("locale") or "")),
+                _clip_log_text(str(req_dict.get("timezone") or "")),
+                _request_client(request),
                 _summarize_action(action),
-                _clip_log_text(transcript),
+                duration_ms,
+                _maybe_log_transcript(transcript),
             )
             return VoiceInterpretResponse(action=action, plan=plan, transcript=transcript)
 
@@ -135,13 +154,71 @@ def voice_interpret(req: VoiceInterpretRequest) -> VoiceInterpretResponse:
                 inflight_entry["event"].set()
 
     _log.info(
-        "voice_interpret request_id=%s action=%s transcript=%s",
+        "voice_interpret request_id=%s status=ok mode=%s locale=%s timezone=%s client=%s action=%s duration_ms=%s transcript=%s",
         req_id or "<none>",
+        _request_mode(req_dict),
+        _clip_log_text(str(req_dict.get("locale") or "")),
+        _clip_log_text(str(req_dict.get("timezone") or "")),
+        _request_client(request),
         _summarize_action(action),
-        _clip_log_text(transcript),
+        _elapsed_ms(started_at),
+        _maybe_log_transcript(transcript),
     )
 
     return VoiceInterpretResponse(action=action, plan=plan, transcript=transcript)
+
+
+def _configured_voice_api_token() -> str:
+    return str(os.environ.get("VOICE_API_TOKEN") or "").strip()
+
+
+def _verify_voice_api_auth(*, req_id: str, authorization: str | None, request: Request | None) -> None:
+    expected = _configured_voice_api_token()
+    if not expected:
+        return
+
+    provided = _parse_bearer_token(authorization)
+    if provided and secrets.compare_digest(provided, expected):
+        return
+
+    _log.warning(
+        "voice_interpret request_id=%s status=unauthorized client=%s",
+        req_id or "<none>",
+        _request_client(request),
+    )
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="missing_or_invalid_auth_token",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+def _parse_bearer_token(authorization: str | None) -> str:
+    raw = str(authorization or "").strip()
+    if not raw:
+        return ""
+    if not raw.lower().startswith("bearer "):
+        return ""
+    return raw[7:].strip()
+
+
+def _request_client(request: Request | None) -> str:
+    if request is None or request.client is None:
+        return "<unknown>"
+    host = str(getattr(request.client, "host", "") or "").strip()
+    return host or "<unknown>"
+
+
+def _request_mode(req_dict: dict[str, Any]) -> str:
+    if str(req_dict.get("audio_base64") or "").strip():
+        return "audio"
+    if str(req_dict.get("transcript") or "").strip():
+        return "transcript"
+    return "empty"
+
+
+def _elapsed_ms(started_at: float) -> int:
+    return max(0, int((time.perf_counter() - float(started_at)) * 1000))
 
 
 def _prune_idempotency_cache_locked(*, now_ts: float | None = None) -> None:
@@ -176,6 +253,13 @@ def _clip_log_text(text: str, max_len: int = 180) -> str:
     if len(txt) <= max_len:
         return txt
     return txt[: max_len - 3] + "..."
+
+
+def _maybe_log_transcript(text: str) -> str:
+    enabled = str(os.environ.get("VOICE_API_LOG_TRANSCRIPT", "0")).strip().lower() in {"1", "true", "yes"}
+    if not enabled:
+        return "<disabled>"
+    return _clip_log_text(text)
 
 
 def _summarize_action(action: dict[str, Any]) -> str:

--- a/docs/VOICE_BACKEND_DEPLOYMENT_RENDER.md
+++ b/docs/VOICE_BACKEND_DEPLOYMENT_RENDER.md
@@ -1,0 +1,208 @@
+# Voice Backend Deployment Baseline (Render + Docker)
+
+This document is the deployment runbook for the hosted Voice API baseline.
+
+## Why This Baseline
+
+Render + Docker is the current baseline because it matches the backend we already have:
+
+- the service is a single long-running FastAPI process
+- the device only needs one stable HTTPS endpoint
+- Render handles HTTPS, health checks, and env var management with low ops overhead
+- Docker keeps the service portable if we move away from Render later
+
+This is intentionally a V1 baseline, not a full platform build-out.
+
+## Deploy Artifacts In Repo
+
+- Docker image: `backend/voice_api/Dockerfile`
+- Render blueprint: `render.yaml`
+- Backend entrypoint: `backend/voice_api/app.py`
+
+## Hosted Environment Variables
+
+Required for hosted operation:
+
+- `GOOGLE_API_KEY`
+  - Gemini API key used by the backend
+- `GEMINI_MODEL`
+  - default baseline: `gemini-2.5-flash`
+- `VOICE_API_TOKEN`
+  - shared device secret; requests to `POST /voice/interpret` are rejected unless they send `Authorization: Bearer <VOICE_API_TOKEN>`
+
+Recommended hosted defaults:
+
+- `VOICE_ENABLE_NO_ACTION_RETRY=0`
+  - keep latency predictable on the first hosted baseline
+- `VOICE_API_LOG_TRANSCRIPT=0`
+  - leave transcript text out of default production logs
+- `VOICE_API_VERBOSE_UPSTREAM=0`
+  - keep `httpx` and `google_genai` noise down in platform logs
+
+Optional advanced tuning:
+
+- `VOICE_CORRECTION_KB_PATH`
+  - override the default local correction KB path if needed
+- `VOICE_API_IDEMPOTENCY_TTL_S`
+- `VOICE_API_IDEMPOTENCY_MAX_SIZE`
+- `VOICE_API_IDEMPOTENCY_WAIT_TIMEOUT_S`
+
+Platform variable:
+
+- `PORT`
+  - Render injects this automatically; the included blueprint pins it to `10000`
+
+## Auth Contract
+
+- `GET /health`
+  - no auth
+  - used for platform uptime checks
+- `POST /voice/interpret`
+  - if `VOICE_API_TOKEN` is configured on the server, request must include:
+    - `Authorization: Bearer <VOICE_API_TOKEN>`
+  - missing or invalid token returns `401`
+
+## Device Configuration
+
+Hardware runner:
+
+```bash
+VOICE_API_URL="https://<your-service>.onrender.com/voice/interpret" \
+VOICE_API_TOKEN="<shared-secret>" \
+python3 tools/run_epaper_console.py
+```
+
+CLI equivalent:
+
+```bash
+python3 tools/run_epaper_console.py \
+  --voice-api-url "https://<your-service>.onrender.com/voice/interpret" \
+  --voice-api-token "<shared-secret>"
+```
+
+Simulator:
+
+```bash
+VOICE_SIM_API_URL="https://<your-service>.onrender.com/voice/interpret" \
+VOICE_SIM_API_TOKEN="<shared-secret>" \
+python3 tools/sim_app_tk.py
+```
+
+## Local Docker Smoke Test
+
+Build:
+
+```bash
+docker build -f backend/voice_api/Dockerfile -t fridge-ink-voice-api .
+```
+
+Run:
+
+```bash
+docker run --rm -p 8000:8000 \
+  -e GOOGLE_API_KEY="${GOOGLE_API_KEY}" \
+  -e GEMINI_MODEL="${GEMINI_MODEL:-gemini-2.5-flash}" \
+  -e VOICE_API_TOKEN="${VOICE_API_TOKEN}" \
+  fridge-ink-voice-api
+```
+
+Health check:
+
+```bash
+curl http://127.0.0.1:8000/health
+```
+
+Interpret smoke test:
+
+```bash
+curl -X POST http://127.0.0.1:8000/voice/interpret \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer ${VOICE_API_TOKEN}" \
+  -d '{
+    "request_id":"smoke-local-1",
+    "request_time":"2026-03-17T12:00:00-04:00",
+    "timezone":"America/Toronto",
+    "locale":"en-US",
+    "transcript":"Add eggs to shopping"
+  }'
+```
+
+## Initial Render Deploy
+
+Option A: blueprint
+
+1. In Render, create a new Blueprint and point it at this repo.
+2. Let Render read `render.yaml`.
+3. Fill in `GOOGLE_API_KEY` and `VOICE_API_TOKEN`.
+4. Keep `GEMINI_MODEL=gemini-2.5-flash` unless you are actively validating another model.
+5. Deploy.
+6. Once the service is live, copy the service URL and set:
+   - `VOICE_API_URL=https://<service>.onrender.com/voice/interpret`
+   - `VOICE_API_TOKEN=<same token configured on Render>`
+
+Option B: manual web service setup
+
+1. Create a new Render Web Service from this repo.
+2. Choose `Docker` runtime.
+3. Set Dockerfile path to `backend/voice_api/Dockerfile`.
+4. Set Docker build context to repo root.
+5. Set health check path to `/health`.
+6. Add the same env vars listed above.
+7. Deploy.
+
+## Post-Deploy Smoke Test
+
+Run these in order:
+
+1. `GET /health` returns `{"status":"ok"}`
+2. `POST /voice/interpret` without auth returns `401` when `VOICE_API_TOKEN` is configured
+3. `POST /voice/interpret` with valid auth succeeds
+4. Device or simulator succeeds against hosted URL for at least:
+   - shopping add
+   - reminder clear confirm flow
+   - inventory add/update
+   - timer set
+   - family board memo add
+
+## Update Flow
+
+1. Make and review the change on a branch.
+2. Merge into the tracked deploy branch.
+3. Let Render auto-deploy the new commit, or trigger a manual deploy for that commit.
+4. Wait for `/health` to pass.
+5. Run the post-deploy smoke test before treating the rollout as complete.
+
+Use config-only deploys when code has not changed:
+
+1. Update env vars in Render.
+2. Trigger redeploy if the platform does not restart automatically.
+3. Re-run `GET /health` and one authenticated interpret smoke test.
+
+## Rollback Flow
+
+Code rollback:
+
+1. In Render, open the deploy history.
+2. Roll back to the last known good deploy.
+3. Confirm `/health`.
+4. Re-run one authenticated interpret smoke test.
+
+Config rollback:
+
+1. Restore the previous env var values in Render.
+2. Redeploy if needed.
+3. Re-run the same smoke tests.
+
+## Logging Baseline
+
+Default backend logs now include enough support context for first-line debugging:
+
+- `request_id`
+- request mode (`audio` or `transcript`)
+- `locale`
+- `timezone`
+- client host
+- action summary
+- request duration
+
+Transcript logging is disabled by default and can be enabled temporarily with `VOICE_API_LOG_TRANSCRIPT=1`.

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,24 @@
+services:
+  - type: web
+    name: fridge-ink-voice-api
+    runtime: docker
+    plan: starter
+    dockerfilePath: ./backend/voice_api/Dockerfile
+    dockerContext: .
+    healthCheckPath: /health
+    autoDeployTrigger: commit
+    envVars:
+      - key: PORT
+        value: "10000"
+      - key: GOOGLE_API_KEY
+        sync: false
+      - key: GEMINI_MODEL
+        value: gemini-2.5-flash
+      - key: VOICE_API_TOKEN
+        sync: false
+      - key: VOICE_ENABLE_NO_ACTION_RETRY
+        value: "0"
+      - key: VOICE_API_LOG_TRANSCRIPT
+        value: "0"
+      - key: VOICE_API_VERBOSE_UPSTREAM
+        value: "0"

--- a/tests/test_voice_client.py
+++ b/tests/test_voice_client.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import os
+import unittest
+
+from app.voice.client import _build_request_headers
+
+
+class VoiceClientTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._orig_voice_api_token = os.environ.get("VOICE_API_TOKEN")
+        os.environ.pop("VOICE_API_TOKEN", None)
+
+    def tearDown(self) -> None:
+        if self._orig_voice_api_token is None:
+            os.environ.pop("VOICE_API_TOKEN", None)
+        else:
+            os.environ["VOICE_API_TOKEN"] = self._orig_voice_api_token
+
+    def test_build_request_headers_uses_explicit_auth_token(self) -> None:
+        headers = _build_request_headers(auth_token="device-secret")
+        self.assertEqual(headers["Authorization"], "Bearer device-secret")
+        self.assertEqual(headers["Content-Type"], "application/json")
+
+    def test_build_request_headers_falls_back_to_env_token(self) -> None:
+        os.environ["VOICE_API_TOKEN"] = "env-secret"
+        headers = _build_request_headers(auth_token=None)
+        self.assertEqual(headers["Authorization"], "Bearer env-secret")
+
+    def test_build_request_headers_omits_authorization_when_token_missing(self) -> None:
+        headers = _build_request_headers(auth_token="")
+        self.assertNotIn("Authorization", headers)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/run_epaper_console.py
+++ b/tools/run_epaper_console.py
@@ -1245,6 +1245,7 @@ def _apply_voice_payload(
 def _voice_interpret_job(
     *,
     api_url: str,
+    auth_token: str,
     audio_path: str,
     voice_locale: str,
     voice_timezone: str,
@@ -1260,6 +1261,7 @@ def _voice_interpret_job(
             meta=meta,
             timeout_s=float(voice_timeout_s),
             board_context=board_context,
+            auth_token=str(auth_token or ""),
         )
         return {
             "ok": True,
@@ -1301,6 +1303,7 @@ def _run_voice_flow(
     panel_gamma: float,
     panel_dither: bool,
     voice_api_url: str,
+    voice_api_token: str,
     voice_locale: str,
     voice_timezone: str,
     voice_timeout_s: float,
@@ -1387,6 +1390,7 @@ def _run_voice_flow(
             meta=meta,
             timeout_s=float(voice_timeout_s),
             board_context=build_board_context(state),
+            auth_token=str(voice_api_token or ""),
         )
         should_render_feedback, _ = _apply_voice_payload(
             state=state,
@@ -1557,6 +1561,11 @@ def main() -> int:
         help="Live weather refresh interval in hours (default: 12; at 12h it aligns to local 00:00/12:00; <=0 disables periodic refresh)",
     )
     parser.add_argument("--voice-api-url", default=os.environ.get("VOICE_API_URL", ""), help="Backend URL for POST /voice/interpret")
+    parser.add_argument(
+        "--voice-api-token",
+        default=os.environ.get("VOICE_API_TOKEN", ""),
+        help="Shared auth token sent as Authorization: Bearer <token>",
+    )
     parser.add_argument("--voice-locale", default=os.environ.get("VOICE_LOCALE", "en-US"), help="Locale sent to backend")
     parser.add_argument("--voice-timezone", default=os.environ.get("VOICE_TIMEZONE", "UTC"), help="Timezone sent to backend")
     parser.add_argument("--voice-timeout", type=float, default=float(os.environ.get("VOICE_TIMEOUT_S", "20")), help="Backend timeout seconds")
@@ -1841,6 +1850,7 @@ def main() -> int:
                     voice_job_future = voice_executor.submit(
                         _voice_interpret_job,
                         api_url=str(args.voice_api_url or ""),
+                        auth_token=str(args.voice_api_token or ""),
                         audio_path=audio,
                         voice_locale=str(state.ui.voice_locale or args.voice_locale or "en-US"),
                         voice_timezone=str(state.ui.device_timezone or args.voice_timezone or "UTC"),
@@ -1882,6 +1892,7 @@ def main() -> int:
                     voice_job_future = voice_executor.submit(
                         _voice_interpret_job,
                         api_url=str(args.voice_api_url or ""),
+                        auth_token=str(args.voice_api_token or ""),
                         audio_path=audio,
                         voice_locale=str(state.ui.voice_locale or args.voice_locale or "en-US"),
                         voice_timezone=str(state.ui.device_timezone or args.voice_timezone or "UTC"),
@@ -2027,6 +2038,7 @@ def main() -> int:
                                     voice_job_future = voice_executor.submit(
                                         _voice_interpret_job,
                                         api_url=str(args.voice_api_url or ""),
+                                        auth_token=str(args.voice_api_token or ""),
                                         audio_path=audio,
                                         voice_locale=str(state.ui.voice_locale or args.voice_locale or "en-US"),
                                         voice_timezone=str(state.ui.device_timezone or args.voice_timezone or "UTC"),
@@ -2194,6 +2206,7 @@ def main() -> int:
                         voice_job_future = voice_executor.submit(
                             _voice_interpret_job,
                             api_url=str(args.voice_api_url or ""),
+                            auth_token=str(args.voice_api_token or ""),
                             audio_path=audio,
                             voice_locale=str(state.ui.voice_locale or args.voice_locale or "en-US"),
                             voice_timezone=str(state.ui.device_timezone or args.voice_timezone or "UTC"),

--- a/tools/sim_app_tk.py
+++ b/tools/sim_app_tk.py
@@ -1297,12 +1297,14 @@ class Simulator(tk.Tk):
         try:
             locale = str(self.state.ui.voice_locale or "en-US")
             meta = build_request_meta(locale=locale, tz_name=_local_timezone_name())
+            auth_token = str(os.environ.get("VOICE_SIM_API_TOKEN", os.environ.get("VOICE_API_TOKEN", "")) or "").strip()
             payload = interpret_audio_via_backend(
                 api_url=api_url,
                 audio_path=audio_path,
                 meta=meta,
                 timeout_s=timeout_s,
                 board_context=build_board_context(self.state),
+                auth_token=auth_token,
             )
             if isinstance(payload, dict):
                 payload = dict(payload)


### PR DESCRIPTION
## Summary
- add the Render/Docker deployment baseline for `backend/voice_api`
- require minimal bearer-token auth for hosted `POST /voice/interpret` while leaving `/health` open
- update simulator/device clients and docs for hosted `VOICE_API_URL` + `VOICE_API_TOKEN`

## Validation
- `PYTHONPATH=. python3 backend/tests/test_app.py`
- `PYTHONPATH=. python3 tests/test_voice_client.py`
- `python3 -m py_compile app/voice/client.py backend/voice_api/app.py tools/run_epaper_console.py tools/sim_app_tk.py`
- hosted smoke test: `GET /health` returns success
- hosted smoke test: unauthenticated `POST /voice/interpret` returns `401`
- hosted smoke test: authenticated `POST /voice/interpret` succeeds against `https://e-board-voice-api.onrender.com/voice/interpret`

## Note
- Simulator has been verified against the hosted deployment
- Pi hosted smoke test via `tools/run_epaper_console.py` has not been explicitly re-run yet

Refs #48