### PR TITLE
fix(firmware): address PR #65 review feedback

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -20,6 +20,7 @@ Serial controls in monitor:
 - `c` (or Enter/Space): click
 - `m`: long-press
 - `b`: back
+- `o`: trigger voice recording (tap once, speak within 5 s)
 - `t<epoch><Enter>`: sync wall clock
 - `v<HH>`: VCOM sweep
 
@@ -62,6 +63,9 @@ firmware/
       display.hpp/.cpp
       clock.hpp/.cpp
       live_data_provider.hpp/.cpp
+      wifi_driver.hpp/.cpp
+      mic_driver.hpp/.cpp
+      voice_client.hpp/.cpp
     ui/
       render_app.hpp/.cpp
       draw.hpp/.cpp
@@ -166,7 +170,44 @@ For behavior changes, verify:
 3. No unexpected `R2_FAST_FULL` spikes.
 4. Product startup expectation (Landing vs Home) is explicitly documented in PR.
 
-## 10. Related Context Files
+## 10. WiFi + Voice Configuration
+
+WiFi and voice backend are configured via `firmware/sdkconfig.defaults`:
+
+```
+CONFIG_WIFI_SSID="YourNetwork"
+CONFIG_WIFI_PASSWORD="YourPassword"
+CONFIG_VOICE_API_URL="http://192.168.x.x:8000"
+CONFIG_VOICE_API_TOKEN="your-token-here"
+```
+
+After editing `sdkconfig.defaults`, always delete `sdkconfig` before rebuilding:
+
+```bash
+rm -f sdkconfig && idf.py build
+```
+
+### Microphone Wiring (NR0562 I2S MEMS)
+
+| Signal | GPIO |
+|--------|------|
+| SCK (BCLK) | 5 |
+| WS (LRCLK) | 6 |
+| SD (Data)  | 7 |
+
+### Voice Action Dispatch
+
+Voice actions returned by the backend are applied to `AppState` via
+`apply_voice_actions()` in `firmware/main/app/reducer.cpp`.
+
+Supported tools (19/19): `open_app`, `shopping_add/remove/clear_all`,
+`inventory_log_event/set_expiry/clear_all`, `timer_set/add/pause/resume/stop`,
+`memo_add/delete/update/clear_all`, `undo/redo_last_action_group`.
+
+Undo/redo history is snapshot-based (up to 10 steps). `open_app` and `no_action`
+are excluded from undo history.
+
+## 11. Related Context Files
 
 - `docs/issues/2026-04-05-issue-51-52-53-closeout-plan.md`
 - `docs/issues/2026-04-08-issue-63-home-portrait-parity-handoff.md`

--- a/firmware/main/app/reducer.cpp
+++ b/firmware/main/app/reducer.cpp
@@ -1647,6 +1647,10 @@ static void va_shopping_add_item(AppState& state, const std::string& args) {
 static void va_shopping_remove_item(AppState& state, const std::string& args) {
   std::string item = va_extract_string(args, "item_name");
   if (item.empty()) item = va_extract_string(args, "item");
+  if (item.empty()) {
+    ESP_LOGW(kTag, "[voice] shopping_remove_item: missing item_name — ignoring");
+    return;
+  }
   const std::string source = va_extract_string(args, "source");
 
   // Helper to hide by index in reminder list.
@@ -1742,9 +1746,9 @@ static void va_memo_delete(AppState& state, const std::string& args) {
   if (position == "last") {
     idx = static_cast<int>(state.dashboard.memos.size()) - 1;
   } else {
-    // Try numeric index.
+    // Backend emits 1-based index; convert to 0-based.
     const int n = va_extract_int(args, "index");
-    if (n > 0 && n < static_cast<int>(state.dashboard.memos.size())) idx = n;
+    if (n >= 1 && n <= static_cast<int>(state.dashboard.memos.size())) idx = n - 1;
   }
   ESP_LOGI(kTag, "[voice] memo_delete: removed memo[%d] \"%s\"",
            idx, state.dashboard.memos[idx].text.c_str());
@@ -1877,8 +1881,9 @@ static void va_memo_update(AppState& state, const std::string& args) {
   int idx = 0;
   const std::string position = va_extract_string(args, "position");
   if (position == "last") idx = static_cast<int>(state.dashboard.memos.size()) - 1;
+  // Backend emits 1-based index; convert to 0-based.
   const int n = va_extract_int(args, "index");
-  if (n > 0 && n < static_cast<int>(state.dashboard.memos.size())) idx = n;
+  if (n >= 1 && n <= static_cast<int>(state.dashboard.memos.size())) idx = n - 1;
 
   state.dashboard.memos[idx].text   = text;
   state.dashboard.memos[idx].is_new = true;
@@ -1898,7 +1903,7 @@ static void va_inventory_log_event(AppState& state, const std::string& args) {
     ESP_LOGW(kTag, "[voice] inventory_log_event: missing item");
     return;
   }
-  if (event == "removed" || event == "used" || event == "consumed") {
+  if (event == "removed" || event == "used" || event == "consumed" || event == "finished") {
     // Try inventory first, then reminder list (AI sometimes conflates them).
     int idx = find_item_index(state.dashboard.inventory_items,
                               state.home.hidden_inventory_indices, item);
@@ -2009,7 +2014,10 @@ static bool is_undo_excluded_tool(const std::string& tool) {
          tool == "redo_last_action_group";
 }
 
-constexpr std::size_t kUndoStackMax = 10;
+// Keep history small: each VoiceSnapshot deep-copies several string vectors.
+// On ESP32-S3 with 8 MB PSRAM allocations route there (>512 B), but we still
+// cap at 5 to avoid runaway heap growth on large lists.
+constexpr std::size_t kUndoStackMax = 5;
 static std::vector<VoiceSnapshot> g_done_stack;  // undo history
 static std::vector<VoiceSnapshot> g_redo_stack;  // redo history
 

--- a/firmware/main/main.cpp
+++ b/firmware/main/main.cpp
@@ -329,6 +329,10 @@ extern "C" void app_main(void) {
   ESP_LOGI(kTag, "Booting Fridge Ink firmware runtime V0");
 
   g_voice_mutex = xSemaphoreCreateMutex();
+  if (g_voice_mutex == nullptr) {
+    ESP_LOGE(kTag, "Failed to create voice mutex — halting");
+    return;
+  }
 
   auto display = fridge_ink::platform::make_default_display();
   fridge_ink::app::Runtime runtime(*display);

--- a/firmware/main/platform/mic_driver.cpp
+++ b/firmware/main/platform/mic_driver.cpp
@@ -103,7 +103,8 @@ std::vector<int16_t> mic_record_pcm(uint32_t max_ms) {
   pcm.reserve(target_samples);
 
   // Single DMA read buffer (int32_t, reused each iteration).
-  static int32_t raw[kDmaBufSamples];
+  // Stack-allocated (not static) so the function is reentrant.
+  int32_t raw[kDmaBufSamples];
 
   const TickType_t deadline =
       xTaskGetTickCount() + pdMS_TO_TICKS(max_ms + 500 /*margin*/);

--- a/firmware/sdkconfig.defaults
+++ b/firmware/sdkconfig.defaults
@@ -14,11 +14,13 @@ CONFIG_SPIRAM_USE_MALLOC=y
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
 
-# WiFi credentials — change to your home network
-CONFIG_WIFI_SSID="You and Me"
-CONFIG_WIFI_PASSWORD="Xx9023149406xX"
+# WiFi credentials — override in a local sdkconfig or via idf.py menuconfig
+# NEVER commit real credentials here.
+CONFIG_WIFI_SSID=""
+CONFIG_WIFI_PASSWORD=""
 
 # Voice backend URL — change to your machine's LAN IP
-CONFIG_VOICE_API_URL="http://192.168.2.39:8000"
+CONFIG_VOICE_API_URL="http://192.168.1.1:8000"
 # Voice backend auth token — must match VOICE_API_TOKEN on the server
-CONFIG_VOICE_API_TOKEN="8e3f1d7c5a9b4e2f91c6d0ab73f4e8c2a1b5d9f0e7c3a6b1"
+# Override locally; do not commit the real token.
+CONFIG_VOICE_API_TOKEN=""


### PR DESCRIPTION
## Summary

Addresses all automated review comments (Gemini + Codex) raised on PR #65.

- **mic_driver**: remove `static` from DMA read buffer — makes `mic_record_pcm` reentrant and thread-safe
- **main**: check `xSemaphoreCreateMutex()` for `NULL` and halt early on failure instead of crashing later
- **reducer**: guard empty `item_name` in `va_shopping_remove_item` — prevents empty string matching the first visible item
- **reducer**: convert backend 1-based memo `index` to 0-based in `va_memo_delete` / `va_memo_update` (off-by-one fix)
- **reducer**: treat `event_type="finished"` as a removal in `va_inventory_log_event` (was falling through to add-branch)
- **reducer**: reduce `kUndoStackMax` 10 → 5 to limit heap pressure on ESP32-S3
- **sdkconfig.defaults**: remove hardcoded WiFi password and API token — replaced with empty defaults and a comment warning against committing real credentials

## Test plan

- [ ] Build firmware — no new warnings
- [ ] Voice: say "remove milk" with empty item_name payload → should log warning and no crash
- [ ] Voice: say "delete memo 2" → should delete the 2nd memo (not the 3rd)
- [ ] Voice: say "I finished the yogurt" → inventory item should be hidden/removed
- [ ] Fresh flash with empty `sdkconfig.defaults` → WiFi skipped gracefully, no credentials in binary
- [ ] Record 5 s of silence → peak check skips POST, no crash from mutex